### PR TITLE
fix time vuln analysis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,8 @@ services:
       -config api.addrs.addr.regex=true
     restart: on-failure
     healthcheck:
+      interval: 5s
+      retries: 10
       test: "curl -f http://localhost:8080/JSON/core/view/version/"
     networks:
       - app_net


### PR DESCRIPTION
Fix in docker compose. The delay was because by default is 30 seconds and if zap takes time to initialize then it takes 60 seconds to start.